### PR TITLE
Race condition causing vault to hang

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,11 +87,14 @@ func main() {
 	if kmsKeyId == "" {
 		log.Fatal("KMS_KEY_ID must be set and not empty")
 	}
-
+	
+	timeout := time.Duration(2 * time.Second)
+	
 	httpClient = http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				Timeout: timeout
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -91,10 +91,10 @@ func main() {
 	timeout := time.Duration(2 * time.Second)
 	
 	httpClient = http.Client{
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
-				Timeout: timeout
 			},
 		},
 	}


### PR DESCRIPTION
There is a race condition occurring where the init container is hanging as the timeout is too long. 